### PR TITLE
Export inp files fix

### DIFF
--- a/Application/cmbNucAssemblyLink.cxx
+++ b/Application/cmbNucAssemblyLink.cxx
@@ -59,3 +59,16 @@ void cmbNucAssemblyLink::SetLegendColor(const QColor& color)
 {
   this->legendColor = color;
 }
+
+cmbNucAssembly * cmbNucAssemblyLink::clone()
+{
+  cmbNucAssembly * result = this->link->clone(this->link->getPinLibrary(),
+                                              this->link->getDuctLibrary());
+  std::string fname = "assembly_" + this->getLabel() + ".inp";
+  std::transform(fname.begin(), fname.end(), fname.begin(), ::tolower);
+  result->setLabel(this->getLabel());
+  result->setFileName(fname);
+  result->GetParameters()->MaterialSet_StartId = this->getMaterialStartID();
+  result->GetParameters()->NeumannSet_StartId = this->getNeumannStartID();
+  return result;
+}

--- a/Application/cmbNucAssemblyLink.h
+++ b/Application/cmbNucAssemblyLink.h
@@ -29,6 +29,8 @@ public:
   virtual std::string getTitle()
   { return "Assembly: " + AssyPartObj::getTitle() + " --> (" + getLink()->getLabel() +")"; }
 
+  cmbNucAssembly * clone();
+
 protected:
   cmbNucAssembly * link;
   std::string materialStartID;

--- a/Application/cmbNucInpExporter.cxx
+++ b/Application/cmbNucInpExporter.cxx
@@ -59,73 +59,65 @@ bool cmbNucInpExporter
     cmbNucAssembly* assembly = NuclearCore->GetAssembly(iter->first);
     if(assembly != NULL)
     {
-        assembly->setPath(coreinfo.dir().absolutePath().toStdString());
-        std::set< Lattice::CellDrawMode > const& forms = iter->second;
-        cmbNucAssembly* assemblyClone = assembly->clone(pl, dl);
-        this->exportInpFile(assemblyClone, false, forms);
-        delete assemblyClone;
+      assembly->setPath(coreinfo.dir().absolutePath().toStdString());
+      std::set< Lattice::CellDrawMode > const& forms = iter->second;
+      cmbNucAssembly* assemblyClone = assembly->clone(pl, dl);
+      this->exportInpFile(assemblyClone, false, forms);
+      delete assemblyClone;
     }
     else
     {
-        // check to see if iter->first is a link        
-        cmbNucAssemblyLink * correspondingLink = NuclearCore->GetAssemblyLink(iter->first);;
-        if (correspondingLink == NULL)
-        {
-            continue;
-        }
-        // correspondingLink is the link that this current iter is linked with
-        // this assumes only 1 link can be had for any label
+      // check to see if iter->first is a link
+      cmbNucAssemblyLink * correspondingLink = NuclearCore->GetAssemblyLink(iter->first);;
+      if (correspondingLink == NULL)
+      {
+        continue;
+      }
+      // correspondingLink is the link that this current iter is linked with
+      // this assumes only 1 link can be had for any label
 
-        std::string linkTargetLabel = correspondingLink->getLink()->getLabel();
-        cmbNucAssembly* linkTargetAssy = NuclearCore->GetAssembly(linkTargetLabel);
+      std::string linkTargetLabel = correspondingLink->getLink()->getLabel();
+      cmbNucAssembly* linkTargetAssy = NuclearCore->GetAssembly(linkTargetLabel);
 
-        if (linkTargetAssy == NULL)
-        {
-            continue;
-        }
+      if (linkTargetAssy == NULL)
+      {
+        continue;
+      }
 
-        // if it is a link but there is no corresponding target assembly with the same mode
-        std::set< Lattice::CellDrawMode > targetForms;
-        for(std::map< std::string, std::set< Lattice::CellDrawMode > >::const_iterator iter2 = cells.begin();
-            iter2 != cells.end(); ++iter2)
+      // if it is a link but there is no corresponding target assembly with the same mode
+      std::set< Lattice::CellDrawMode > targetForms;
+      for(std::map< std::string, std::set< Lattice::CellDrawMode > >::const_iterator iter2 = cells.begin();
+          iter2 != cells.end(); ++iter2)
+      {
+        if (iter2->first.compare(linkTargetAssy->getLabel()) != 0)
         {
-            if (iter2->first.compare(linkTargetAssy->getLabel()) != 0)
-            {
-                continue;
-            }
-            targetForms = iter2->second;
+          continue;
         }
-        if (targetForms.size() == 0)
-        {
-            continue;
-        }
-        // targetForms has the modes of the target
-        // check to see if the link mode exists for this target
+        targetForms = iter2->second;
+      }
+      if (targetForms.size() == 0)
+      {
+        continue;
+      }
+      // targetForms has the modes of the target
+      // check to see if the link mode exists for this target
 
-        // since we have to conditionally check every mode for writing out,
-        // we need to create sets containing 1 mode each
-        for (std::set< Lattice::CellDrawMode >::const_iterator mode = iter->second.begin();
-             mode != iter->second.end(); ++mode)
-        {
-            if (targetForms.count(*mode) > 0)
-            {
-                // No need to write out this inp, as the target will do so for this mode
-                continue;
-            }
+      // since we have to conditionally check every mode for writing out,
+      // we need to create sets containing 1 mode each
+      std::set< Lattice::CellDrawMode > forms;
+      linkTargetAssy->setPath(coreinfo.dir().absolutePath().toStdString());
+      cmbNucAssembly* assemblyClone = correspondingLink->clone();
 
-            // clone the link target assembly and write it out with the link mode
-            // same as above. Maybe worth merging?
-            linkTargetAssy->setPath(coreinfo.dir().absolutePath().toStdString());
-            std::set< Lattice::CellDrawMode > forms;
-            forms.insert(*mode);
-            cmbNucAssembly* assemblyClone = linkTargetAssy->clone(pl, dl);
-            assemblyClone->setLabel(iter->first);
-            std::string fname = "assembly_" + assemblyClone->getLabel() + ".inp";
-            std::transform(fname.begin(), fname.end(), fname.begin(), ::tolower);
-            assemblyClone->setFileName(fname);
-            this->exportInpFile(assemblyClone, false, forms);
-            delete assemblyClone;
+      for (std::set< Lattice::CellDrawMode >::const_iterator mode = iter->second.begin();
+           mode != iter->second.end(); ++mode)
+      {
+        if (targetForms.count(*mode) == 0)
+        {
+          forms.insert(*mode);
         }
+      }
+      this->exportInpFile(assemblyClone, false, forms);
+      delete assemblyClone;
     }
   }
   if(this->NuclearCore->changeSinceLastGenerate())
@@ -265,7 +257,7 @@ bool cmbNucInpExporter
     }
 
     Lattice::CellDrawMode mode = *fiter;
-    std::string const& fname = assy->getFileName(mode, forms.size()+1);
+    std::string const& fname = assy->getFileName(mode, forms.size());
 
     switch(mode)
     {

--- a/Application/cmbNucInpExporter.cxx
+++ b/Application/cmbNucInpExporter.cxx
@@ -92,6 +92,9 @@ bool cmbNucInpExporter
         std::set< Lattice::CellDrawMode > const& forms = iter->second;
         cmbNucAssembly* assemblyClone = linkTargetAssy->clone(pl, dl);
         assemblyClone->setLabel(iter->first);
+        std::string fname = "assembly_" + assemblyClone->getLabel() + ".inp";
+        std::transform(fname.begin(), fname.end(), fname.begin(), ::tolower);
+        assemblyClone->setFileName(fname);
         this->exportInpFile(assemblyClone, false, forms);
         delete assemblyClone;
     }

--- a/Application/cmbNucInpExporter.cxx
+++ b/Application/cmbNucInpExporter.cxx
@@ -72,14 +72,6 @@ bool cmbNucInpExporter
         // clone the link target assembly and write it out with the link mode
 
         cmbNucAssemblyLink * correspondingLink = NuclearCore->GetAssemblyLink(iter->first);;
-//        for(std::vector< cmbNucAssemblyLink* >::const_iterator link_iter = NuclearCore->AssemblyLinks.begin(); link_iter != NuclearCore->AssemblyLinks.end(); ++link_iter)
-//        {
-//            if (link_iter->getLabel().compare(iter->getLabel()) == 0)
-//            {
-//                correspondingLink = *link_iter;
-//                break;
-//            }
-//        }
         if (correspondingLink == NULL)
         {
             continue;
@@ -87,7 +79,6 @@ bool cmbNucInpExporter
         // correspondingLink is the link that this current iter is linked with
         // this assumes only 1 link can be had for any label
 
-        //std::string linkTargetLabel = correspondingLink->link.getLabel();
         std::string linkTargetLabel = correspondingLink->getLink()->getLabel();
         cmbNucAssembly* linkTargetAssy = NuclearCore->GetAssembly(linkTargetLabel);
 
@@ -95,16 +86,6 @@ bool cmbNucInpExporter
         {
             continue;
         }
-
-        // now find the assembly that goes along with the linkTargetLabel
-//        for(std::vector< cmbNucAssembly* >::const_iterator assy_iter = NuclearCore->AssemblyLinks.begin(); assy_iter != NuclearCore->AssemblyLinks.end(); ++assy_iter)
-//        {
-//            if (assy_iter->getLabel().compare(linkTargetLabel) == 0)
-//            {
-//                linkTargetAssy = *assy_iter;
-//                break;
-//            }
-//        }
 
         // same as above. Maybe worth merging?
         linkTargetAssy->setPath(coreinfo.dir().absolutePath().toStdString());

--- a/Application/cmbNucInpExporter.h
+++ b/Application/cmbNucInpExporter.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <algorithm>
 
 #include "cmbNucLattice.h"
 

--- a/Application/inpFileIO.cxx
+++ b/Application/inpFileIO.cxx
@@ -2012,7 +2012,7 @@ void inpFileHelper::writeAssemblies( std::ofstream &output,
         break;
       }
     }
-    // todo: If mode unassigned, we need to write out assembly for this link ('v2 bug')
+    // todo: If modes unassigned, what do? link w/o modes?
 
     // loop through cell pairs of the assembly we want to link with
     // and make sure there is one for the same drawmode
@@ -2047,13 +2047,19 @@ void inpFileHelper::writeAssemblies( std::ofstream &output,
 
               usedLinksForWriteOut.push_back(std::pair<cmbNucAssemblyLink*, Lattice::CellDrawMode>(tmpLink, mode));
             }
-            //else...'v2' bug
+            //'v2' bug
+            else
+            {
+                // mode has nothing to link to,
+                // so make it a "real" assembly
+                // and make sure it is written out as such
 
+
+            }
         }
       }
     }
   }
-
 
   output << "Assemblies " << count;
   output << " " << core.getAssemblyPitchX();

--- a/Application/inpFileIO.cxx
+++ b/Application/inpFileIO.cxx
@@ -1999,7 +1999,7 @@ void inpFileHelper::writeAssemblies( std::ofstream &output,
     std::string assyPartLabel = link->getLabel();
 
     // Get the drawmode for this link
-    Lattice::CellDrawMode mode;
+    std::set<Lattice::CellDrawMode> modes;
     for(CellMap::const_iterator cell_iter = cells.begin();
       cell_iter != cells.end(); ++cell_iter)
     {
@@ -2008,7 +2008,7 @@ void inpFileHelper::writeAssemblies( std::ofstream &output,
       {
         // Get the mode corresponding to the matched cell
         //mode = core.GetAssembly(cell_iter->first)->getLattice().getDrawMode(0,0);
-        mode = *(cell_iter->second.begin());
+        modes = cell_iter->second;
         break;
       }
     }
@@ -2025,22 +2025,31 @@ void inpFileHelper::writeAssemblies( std::ofstream &output,
       {
         // cell_iter is the cellpair with our link's target
         std::set<Lattice::CellDrawMode> validModes = cell_iter->second;
-        // search for the mode our link is in
-        std::set<Lattice::CellDrawMode>::iterator it = validModes.find(mode);
-        if (it != validModes.end())
-        {
-          // The mode exists
-          // Create/Assign our temp this link
-          cmbNucAssemblyLink * tmpLink = new cmbNucAssemblyLink(assembly,
-                                                                link->getMaterialStartID(),
-                                                                link->getNeumannStartID());
-          std::string tmpLabel = assyPartLabel;
-          tmpLabel = Lattice::generate_string(tmpLabel, mode);
-          tmpLink->setLabel(tmpLabel);
 
-          usedLinksForWriteOut.push_back(std::pair<cmbNucAssemblyLink*, Lattice::CellDrawMode>(tmpLink, mode));
+        // iterate through all the modes the link could be in
+        for(ModeSet::const_iterator modes_iter = modes.begin();
+            modes_iter != modes.end(); ++modes_iter)
+        {
+            Lattice::CellDrawMode mode = *modes_iter;
+
+            // search for the mode our link is in
+            std::set<Lattice::CellDrawMode>::iterator it = validModes.find(mode);
+            if (it != validModes.end())
+            {
+              // The mode exists
+              // Create/Assign our temp this link
+              cmbNucAssemblyLink * tmpLink = new cmbNucAssemblyLink(assembly,
+                                                                    link->getMaterialStartID(),
+                                                                    link->getNeumannStartID());
+              std::string tmpLabel = assyPartLabel;
+              tmpLabel = Lattice::generate_string(tmpLabel, mode);
+              tmpLink->setLabel(tmpLabel);
+
+              usedLinksForWriteOut.push_back(std::pair<cmbNucAssemblyLink*, Lattice::CellDrawMode>(tmpLink, mode));
+            }
+            //else...'v2' bug
+
         }
-        //else...'v2' bug
       }
     }
   }


### PR DESCRIPTION
Exported inp files now correctly show assembly links. If the links are the only assemblies for a particular mode, an inp file for the link is written out.